### PR TITLE
Update account_payment_mode.py

### DIFF
--- a/account_payment_order_vendor_email/models/account_payment_mode.py
+++ b/account_payment_order_vendor_email/models/account_payment_mode.py
@@ -59,7 +59,7 @@ class PaymentOrder(models.Model):
                             "discount": payment_line.discount_amount,
                             "inv_date": invoice_date or "",
                             "credit_ref": payment_line.order_id.name,
-                            "supp_inv": payment_line.move_line_id.move_id.name or "",
+                            "supp_inv": payment_line.move_line_id.move_id.payment_reference or "",
                             "inv_amount": payment_line.move_line_id.move_id.amount_total,
                             "credit_amount": payment_line.move_line_id.move_id.amount_untaxed,
                             "due_amount": payment_line.move_line_id.move_id.amount_residual,


### PR DESCRIPTION
[36406] Supplier Invoice field on the email template needs to refer to payment reference on the invoice and not the invoice name itself.